### PR TITLE
Improve default nozzle machine configs and silent steppers

### DIFF
--- a/klipper_config/printer.cfg
+++ b/klipper_config/printer.cfg
@@ -1,7 +1,7 @@
 ####################################################################################
 # Machine type: OrangeStorm Giga
-# Current configuration version: V1.2.2
-# Date: 2024-08-22
+# Current configuration version: V1.2.3
+# Date: 2024-09-04
 ;                          +++                        
 ;                       +++++                         
 ;              +       ++++++      ++                 
@@ -292,9 +292,9 @@ retry_tolerance: 0.01
 uart_pin: PE5
 run_current: 1.8
 hold_current: 1.0
-interpolate: False
-#interpolate: True
-#stealthchop_threshold:99999
+#interpolate: False
+interpolate: True
+stealthchop_threshold:99999
 # driver_SGTHRS:80
 # diag_pin:^PD0
 
@@ -307,23 +307,25 @@ spi_speed:200000
 run_current: 2.8
 hold_current: 1.5
 sense_resistor: 0.033
-interpolate:False
-#interpolate:True
-#stealthchop_threshold:99999
+#interpolate: False
+interpolate: True
+#stealthchop_threshold:99999 # does not reduce noise on stepper_y
 
 [tmc2209 stepper_z]
 uart_pin: PB5
 run_current: 1.2
 hold_current: 1.2
-#interpolate: True
-#stealthchop_threshold: 120
+#interpolate: False
+interpolate: True
+stealthchop_threshold:99999
 
 [tmc2209 stepper_z1]
 uart_pin: PD5
 run_current: 1.2
 hold_current: 1.2
-#interpolate: True
-#stealthchop_threshold: 120
+#interpolate: False
+interpolate: True
+stealthchop_threshold:99999
 
 [motor_constants ldo-42sth60-2004ac]
 resistance: 0.45#2.1

--- a/orca_slicer_config/profiles/Elegoo/machine/Elegoo Orangestorm Giga (0.6 nozzle).json
+++ b/orca_slicer_config/profiles/Elegoo/machine/Elegoo Orangestorm Giga (0.6 nozzle).json
@@ -22,10 +22,10 @@
     "nozzle_type": "hardened_steel",
     "auxiliary_fan": "0",
     "max_layer_height": [
-        "0.4"
+        "0.48"
     ],
     "min_layer_height": [
-        "0.08"
+        "0.12"
     ],
     "printer_settings_id": "Elegoo",
     "retraction_minimum_travel": [

--- a/orca_slicer_config/profiles/Elegoo/machine/Elegoo Orangestorm Giga (0.8 nozzle).json
+++ b/orca_slicer_config/profiles/Elegoo/machine/Elegoo Orangestorm Giga (0.8 nozzle).json
@@ -22,10 +22,10 @@
     "nozzle_type": "hardened_steel",
     "auxiliary_fan": "0",
     "max_layer_height": [
-        "0.6"
+        "0.64"
     ],
     "min_layer_height": [
-        "0.08"
+        "0.16"
     ],
     "printer_settings_id": "Elegoo",
     "retraction_minimum_travel": [

--- a/orca_slicer_config/profiles/Elegoo/machine/Elegoo Orangestorm Giga (1.0 nozzle).json
+++ b/orca_slicer_config/profiles/Elegoo/machine/Elegoo Orangestorm Giga (1.0 nozzle).json
@@ -25,7 +25,7 @@
         "0.8"
     ],
     "min_layer_height": [
-        "0.08"
+        "0.20"
     ],
     "printer_settings_id": "Elegoo",
     "retraction_minimum_travel": [


### PR DESCRIPTION
1. Enable [Stealthchop ](https://www.klipper3d.org/TMC_Drivers.html#setting-spreadcycle-vs-stealthchop-mode) and Interpolate for X and Z stepper drivers.
2. Enable Interpolate on Y stepper driver.
3. Correct min and max layer height for 0.6, 0.8, 1.0 mm nozzles.